### PR TITLE
Use slashes in Nopipeline.Task.targets to make it compatible with .Net Core on Linux.

### DIFF
--- a/Nopipeline/Nopipeline.Task/Nopipeline.Task.targets
+++ b/Nopipeline/Nopipeline.Task/Nopipeline.Task.targets
@@ -5,7 +5,7 @@
 	</ItemGroup>
 
 	<Target Name="Nopipeline">
-		<Exec Command="dotnet $(MSBuildThisFileDirectory)\..\tools\netcoreapp3.1\any\npl.dll &quot;%(NPLContentReferences.FullPath)&quot;" />
-		<Exec Command="dotnet $(MSBuildThisFileDirectory)\..\tools\netcoreapp3.1\any\npl.dll &quot;%(MGCBContentReferences.FullPath)&quot;" />
+		<Exec Command="dotnet $(MSBuildThisFileDirectory)/../tools/netcoreapp3.1/any/npl.dll &quot;%(NPLContentReferences.FullPath)&quot;" />
+		<Exec Command="dotnet $(MSBuildThisFileDirectory)/../tools/netcoreapp3.1/any/npl.dll &quot;%(MGCBContentReferences.FullPath)&quot;" />
 	</Target>
 </Project>


### PR DESCRIPTION
Related to #11. Tested on Windows and Linux.